### PR TITLE
Refactor tests to use page objects

### DIFF
--- a/src/components/common/AboutModal/__test__/AboutModal.test.to.ts
+++ b/src/components/common/AboutModal/__test__/AboutModal.test.to.ts
@@ -1,20 +1,11 @@
-import { renderWithProviders } from '@/lib/test/renderWithProviders';
-import { AboutModal } from '..';
 import { BasePageClass } from '@/lib/test/BasePageClass.to';
 import { aboutInfo } from '@/constants/about';
 import { RenderResult } from '@testing-library/react';
 
-class AboutModalPage extends BasePageClass {
+export class AboutModalPage extends BasePageClass {
   first: HTMLElement;
   constructor(result: RenderResult) {
     super(result);
     this.first = result.getByText(aboutInfo.detailedDescriptions[0]);
   }
 }
-
-describe('AboutModal PO', () => {
-  it('exposes first paragraph', () => {
-    const page = new AboutModalPage(renderWithProviders(<AboutModal />));
-    expect(page.first).toBeInTheDocument();
-  });
-});

--- a/src/components/common/AboutModal/__test__/AboutModal.test.tsx
+++ b/src/components/common/AboutModal/__test__/AboutModal.test.tsx
@@ -1,11 +1,11 @@
 import { renderWithProviders } from '@/lib/test/renderWithProviders';
 import { AboutModal } from '..';
-import { aboutInfo } from '@/constants/about';
 import { screen } from '@testing-library/react';
+import { AboutModalPage } from './AboutModal.test.to';
 
 describe('AboutModal', () => {
   it('renders paragraphs from about info', () => {
-    renderWithProviders(<AboutModal />);
-    expect(screen.getByText(aboutInfo.detailedDescriptions[0])).toBeInTheDocument();
+    const page = new AboutModalPage(renderWithProviders(<AboutModal />));
+    expect(page.first).toBeInTheDocument();
   });
 });

--- a/src/components/common/CircleButton/__test__/CircleButton.test.to.ts
+++ b/src/components/common/CircleButton/__test__/CircleButton.test.to.ts
@@ -1,21 +1,12 @@
-import { renderWithProviders } from '@/lib/test/renderWithProviders';
-import { CircleButton } from '..';
 import { BasePageClass } from '@/lib/test/BasePageClass.to';
 import { ButtonTO } from '@/lib/test/Button.to';
 
 import { RenderResult } from '@testing-library/react';
 
-class CircleButtonPage extends BasePageClass {
+export class CircleButtonPage extends BasePageClass {
   button: ButtonTO;
   constructor(result: RenderResult) {
     super(result);
     this.button = new ButtonTO(result, 'circle button');
   }
 }
-
-describe('CircleButton PO', () => {
-  it('should render and expose button', () => {
-    const page = new CircleButtonPage(renderWithProviders(<CircleButton />));
-    expect(page.button.element).toBeInTheDocument();
-  });
-});

--- a/src/components/common/CircleButton/__test__/CircleButton.test.tsx
+++ b/src/components/common/CircleButton/__test__/CircleButton.test.tsx
@@ -1,10 +1,11 @@
 import { renderWithProviders } from '@/lib/test/renderWithProviders';
 import { CircleButton } from '..';
 import { screen } from '@testing-library/react';
+import { CircleButtonPage } from './CircleButton.test.to';
 
 describe('CircleButton', () => {
   it('renders button with arrow icon', () => {
-    renderWithProviders(<CircleButton />);
-    expect(screen.getByRole('button', { name: 'circle button' })).toBeInTheDocument();
+    const page = new CircleButtonPage(renderWithProviders(<CircleButton />));
+    expect(page.button.element).toBeInTheDocument();
   });
 });

--- a/src/components/common/CustomImage/__test__/CustomImage.test.to.ts
+++ b/src/components/common/CustomImage/__test__/CustomImage.test.to.ts
@@ -1,19 +1,10 @@
-import { renderWithProviders } from '@/lib/test/renderWithProviders';
-import { CustomImage } from '..';
 import { BasePageClass } from '@/lib/test/BasePageClass.to';
 import { RenderResult } from '@testing-library/react';
 
-class CustomImagePage extends BasePageClass {
+export class CustomImagePage extends BasePageClass {
   img: HTMLElement;
   constructor(result: RenderResult) {
     super(result);
     this.img = result.getByAltText('logo');
   }
 }
-
-describe('CustomImage PO', () => {
-  it('exposes img element', () => {
-    const page = new CustomImagePage(renderWithProviders(<CustomImage src="/img.png" alt="logo" />));
-    expect(page.img).toBeInTheDocument();
-  });
-});

--- a/src/components/common/CustomImage/__test__/CustomImage.test.tsx
+++ b/src/components/common/CustomImage/__test__/CustomImage.test.tsx
@@ -1,10 +1,11 @@
 import { renderWithProviders } from '@/lib/test/renderWithProviders';
 import { CustomImage } from '..';
 import { screen } from '@testing-library/react';
+import { CustomImagePage } from './CustomImage.test.to';
 
 describe('CustomImage', () => {
   it('renders img with provided src', () => {
-    renderWithProviders(<CustomImage src="/img.png" alt="logo" />);
-    expect(screen.getByAltText('logo')).toHaveAttribute('src', '/img.png');
+    const page = new CustomImagePage(renderWithProviders(<CustomImage src="/img.png" alt="logo" />));
+    expect(page.img).toHaveAttribute('src', '/img.png');
   });
 });

--- a/src/components/common/ExperienceCard/__test__/ExperienceCard.test.to.ts
+++ b/src/components/common/ExperienceCard/__test__/ExperienceCard.test.to.ts
@@ -1,22 +1,11 @@
-import { renderWithProviders } from '@/lib/test/renderWithProviders';
-import { ExperienceCard } from '..';
 import { BasePageClass } from '@/lib/test/BasePageClass.to';
 import { ButtonTO } from '@/lib/test/Button.to';
 import { RenderResult } from '@testing-library/react';
 
-class ExperienceCardPage extends BasePageClass {
+export class ExperienceCardPage extends BasePageClass {
   button: ButtonTO;
   constructor(result: RenderResult) {
     super(result);
-    this.button = new ButtonTO(result, 'See More');
+    this.button = new ButtonTO(result, 'gradient button');
   }
 }
-
-describe('ExperienceCard PO', () => {
-  it('exposes see more button', () => {
-    const page = new ExperienceCardPage(renderWithProviders(
-      <ExperienceCard number="01" title="Dev" description="desc" />
-    ));
-    expect(page.button.element).toBeInTheDocument();
-  });
-});

--- a/src/components/common/ExperienceCard/__test__/ExperienceCard.test.tsx
+++ b/src/components/common/ExperienceCard/__test__/ExperienceCard.test.tsx
@@ -1,13 +1,17 @@
 import { renderWithProviders } from '@/lib/test/renderWithProviders';
 import { ExperienceCard } from '..';
 import { screen } from '@testing-library/react';
+import { ExperienceCardPage } from './ExperienceCard.test.to';
 
 describe('ExperienceCard', () => {
   it('renders card details', () => {
-    renderWithProviders(
-      <ExperienceCard number="01" title="Dev" description="desc" />
+    const page = new ExperienceCardPage(
+      renderWithProviders(
+        <ExperienceCard number="01" title="Dev" description="desc" />,
+      ),
     );
     expect(screen.getByText('Dev')).toBeInTheDocument();
     expect(screen.getByText('desc')).toBeInTheDocument();
+    expect(page.button.element).toBeInTheDocument();
   });
 });

--- a/src/components/common/ExperienceModal/__test__/ExperienceModal.test.to.ts
+++ b/src/components/common/ExperienceModal/__test__/ExperienceModal.test.to.ts
@@ -1,22 +1,11 @@
-import { renderWithProviders } from '@/lib/test/renderWithProviders';
-import { ExperienceModal } from '..';
 import { BasePageClass } from '@/lib/test/BasePageClass.to';
 import { workExperiences } from '@/constants/experience';
 import { RenderResult } from '@testing-library/react';
 
-class ExperienceModalPage extends BasePageClass {
+export class ExperienceModalPage extends BasePageClass {
   heading: HTMLElement;
   constructor(result: RenderResult) {
     super(result);
     this.heading = result.getByText(workExperiences[0].period);
   }
 }
-
-describe('ExperienceModal PO', () => {
-  it('exposes period', () => {
-    const page = new ExperienceModalPage(renderWithProviders(
-      <ExperienceModal experience={workExperiences[0]} />
-    ));
-    expect(page.heading).toBeInTheDocument();
-  });
-});

--- a/src/components/common/ExperienceModal/__test__/ExperienceModal.test.tsx
+++ b/src/components/common/ExperienceModal/__test__/ExperienceModal.test.tsx
@@ -2,10 +2,13 @@ import { renderWithProviders } from '@/lib/test/renderWithProviders';
 import { ExperienceModal } from '..';
 import { workExperiences } from '@/constants/experience';
 import { screen } from '@testing-library/react';
+import { ExperienceModalPage } from './ExperienceModal.test.to';
 
 describe('ExperienceModal', () => {
   it('renders experience details', () => {
-    renderWithProviders(<ExperienceModal experience={workExperiences[0]} />);
-    expect(screen.getByText(workExperiences[0].period)).toBeInTheDocument();
+    const page = new ExperienceModalPage(
+      renderWithProviders(<ExperienceModal experience={workExperiences[0]} />),
+    );
+    expect(page.heading).toBeInTheDocument();
   });
 });

--- a/src/components/common/Footer/__test__/Footer.test.to.ts
+++ b/src/components/common/Footer/__test__/Footer.test.to.ts
@@ -1,19 +1,10 @@
-import { renderWithProviders } from '@/lib/test/renderWithProviders';
-import { Footer } from '..';
 import { BasePageClass } from '@/lib/test/BasePageClass.to';
 import { RenderResult } from '@testing-library/react';
 
-class FooterPage extends BasePageClass {
+export class FooterPage extends BasePageClass {
   nav: HTMLElement;
   constructor(result: RenderResult) {
     super(result);
     this.nav = result.getByRole('navigation');
   }
 }
-
-describe('Footer PO', () => {
-  it('exposes nav element', () => {
-    const page = new FooterPage(renderWithProviders(<Footer />));
-    expect(page.nav).toBeInTheDocument();
-  });
-});

--- a/src/components/common/Footer/__test__/Footer.test.tsx
+++ b/src/components/common/Footer/__test__/Footer.test.tsx
@@ -1,10 +1,10 @@
 import { renderWithProviders } from '@/lib/test/renderWithProviders';
 import { Footer } from '..';
-import { screen } from '@testing-library/react';
+import { FooterPage } from './Footer.test.to';
 
 describe('Footer', () => {
   it('renders navigation links', () => {
-    renderWithProviders(<Footer />);
-    expect(screen.getByRole('navigation')).toBeInTheDocument();
+    const page = new FooterPage(renderWithProviders(<Footer />));
+    expect(page.nav).toBeInTheDocument();
   });
 });

--- a/src/components/common/Form/InputField/__test__/InputField.test.to.ts
+++ b/src/components/common/Form/InputField/__test__/InputField.test.to.ts
@@ -1,26 +1,13 @@
-import { renderWithProviders } from '@/lib/test/renderWithProviders';
-import { InputField } from '..';
 import { BasePageClass } from '@/lib/test/BasePageClass.to';
 import { FormFieldTO } from '@/lib/test/FormField.to';
 
 import { RenderResult } from '@testing-library/react';
 
-class InputFieldPage extends BasePageClass {
+export class InputFieldPage extends BasePageClass {
   input: FormFieldTO;
-  constructor(result: RenderResult) {
+  constructor(result: RenderResult, label: string = 'Email') {
     super(result);
-    this.input = new FormFieldTO(result, 'Email');
+    this.input = new FormFieldTO(result, label);
   }
 }
 
-describe('InputField PO', () => {
-  it('allows typing', () => {
-    const handleChange = jest.fn();
-    const page = new InputFieldPage(renderWithProviders(
-      <InputField label="Email" id="email" type="email" value="" onChange={handleChange} />,
-    ));
-    page.input.input.focus();
-    page.input.input.dispatchEvent(new Event('change', { bubbles: true }));
-    expect(page.input.input).toBeInTheDocument();
-  });
-});

--- a/src/components/common/Form/InputField/__test__/InputField.test.tsx
+++ b/src/components/common/Form/InputField/__test__/InputField.test.tsx
@@ -1,14 +1,28 @@
 import { renderWithProviders } from '@/lib/test/renderWithProviders';
 import { InputField } from '..';
 import { screen } from '@testing-library/react';
+import { InputFieldPage } from './InputField.test.to';
 
 describe('InputField', () => {
-  it('renders input with label', () => {
+  it('renders input with label and handles change', () => {
     const handleChange = jest.fn();
-    renderWithProviders(
-      <InputField label="Email" id="email" type="email" value="" onChange={handleChange} />,
+    const page = new InputFieldPage(
+      renderWithProviders(
+        <InputField label="Email" id="email" type="email" value="" onChange={handleChange} />,
+      ),
     );
-    const input = screen.getByLabelText('Email');
-    expect(input).toBeInTheDocument();
+    page.input.type('hello');
+    expect(handleChange).toHaveBeenCalledWith('hello');
+    expect(page.input.input).toBeInTheDocument();
+  });
+
+  it('defaults to text type', () => {
+    const page = new InputFieldPage(
+      renderWithProviders(
+        <InputField label="Name" id="name" value="" onChange={jest.fn()} />,
+      ),
+      'Name',
+    );
+    expect(page.input.input).toHaveAttribute('type', 'text');
   });
 });

--- a/src/components/common/Form/TextAreaField/__test__/TextAreaField.test.to.ts
+++ b/src/components/common/Form/TextAreaField/__test__/TextAreaField.test.to.ts
@@ -1,23 +1,12 @@
-import { renderWithProviders } from '@/lib/test/renderWithProviders';
-import { TextAreaField } from '..';
 import { BasePageClass } from '@/lib/test/BasePageClass.to';
 import { FormFieldTO } from '@/lib/test/FormField.to';
 
 import { RenderResult } from '@testing-library/react';
 
-class TextAreaFieldPage extends BasePageClass {
+export class TextAreaFieldPage extends BasePageClass {
   field: FormFieldTO;
   constructor(result: RenderResult) {
     super(result);
     this.field = new FormFieldTO(result, 'Message');
   }
 }
-
-describe('TextAreaField PO', () => {
-  it('exposes textarea', () => {
-    const page = new TextAreaFieldPage(renderWithProviders(
-      <TextAreaField label="Message" id="msg" value="" onChange={jest.fn()} />,
-    ));
-    expect(page.field.input).toBeInTheDocument();
-  });
-});

--- a/src/components/common/Form/TextAreaField/__test__/TextAreaField.test.tsx
+++ b/src/components/common/Form/TextAreaField/__test__/TextAreaField.test.tsx
@@ -1,6 +1,7 @@
 import { renderWithProviders } from '@/lib/test/renderWithProviders';
 import { TextAreaField } from '..';
 import { screen } from '@testing-library/react';
+import { TextAreaFieldPage } from './TextAreaField.test.to';
 
 describe('TextAreaField', () => {
   it('renders textarea with label', () => {
@@ -8,5 +9,16 @@ describe('TextAreaField', () => {
       <TextAreaField label="Message" id="msg" value="hi" onChange={jest.fn()} />,
     );
     expect(screen.getByLabelText('Message')).toBeInTheDocument();
+  });
+
+  it('calls onChange when typing', () => {
+    const handleChange = jest.fn();
+    const page = new TextAreaFieldPage(
+      renderWithProviders(
+        <TextAreaField label="Message" id="msg" value="" onChange={handleChange} />,
+      ),
+    );
+    page.field.type('test');
+    expect(handleChange).toHaveBeenCalledWith('test');
   });
 });

--- a/src/components/common/GradientButton/__test__/GradientButton.test.to.ts
+++ b/src/components/common/GradientButton/__test__/GradientButton.test.to.ts
@@ -1,25 +1,12 @@
-import { renderWithProviders } from '@/lib/test/renderWithProviders';
-import { GradientButton } from '..';
 import { BasePageClass } from '@/lib/test/BasePageClass.to';
 import { ButtonTO } from '@/lib/test/Button.to';
 
 import { RenderResult } from '@testing-library/react';
 
-class GradientButtonPage extends BasePageClass {
+export class GradientButtonPage extends BasePageClass {
   button: ButtonTO;
   constructor(result: RenderResult) {
     super(result);
     this.button = new ButtonTO(result, 'gradient button');
   }
 }
-
-describe('GradientButton PO', () => {
-  it('should render and interact', () => {
-    const handleClick = jest.fn();
-    const page = new GradientButtonPage(renderWithProviders(
-      <GradientButton onClick={handleClick}>Text</GradientButton>,
-    ));
-    page.button.element.click();
-    expect(handleClick).toHaveBeenCalled();
-  });
-});

--- a/src/components/common/GradientButton/__test__/GradientButton.test.tsx
+++ b/src/components/common/GradientButton/__test__/GradientButton.test.tsx
@@ -1,10 +1,41 @@
 import { renderWithProviders } from '@/lib/test/renderWithProviders';
 import { GradientButton } from '..';
 import { screen } from '@testing-library/react';
+import { GradientButtonPage } from './GradientButton.test.to';
 
 describe('GradientButton', () => {
   it('renders button with children', () => {
-    renderWithProviders(<GradientButton>Test</GradientButton>);
-    expect(screen.getByRole('button', { name: 'gradient button' })).toBeInTheDocument();
+    const page = new GradientButtonPage(renderWithProviders(<GradientButton>Test</GradientButton>));
+    expect(page.button.element).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', () => {
+    const handleClick = jest.fn();
+    const page = new GradientButtonPage(renderWithProviders(<GradientButton onClick={handleClick}>Go</GradientButton>));
+    page.button.click();
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('renders as link when href provided', () => {
+    renderWithProviders(<GradientButton href="https://example.com">Link</GradientButton>);
+    expect(screen.getByRole('link', { name: 'gradient button' })).toHaveAttribute('href', 'https://example.com');
+  });
+
+  it('handles hover animations', () => {
+    const page = new GradientButtonPage(renderWithProviders(<GradientButton>Hover</GradientButton>));
+    const button = page.button.element;
+    button.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    button.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
+    expect(button).toBeInTheDocument();
+  });
+
+  it('link hover and attributes', () => {
+    const page = new GradientButtonPage(
+      renderWithProviders(<GradientButton href="#test">Link</GradientButton>),
+    );
+    const link = screen.getByRole('link', { name: 'gradient button' });
+    link.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    link.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
+    expect(link).toHaveAttribute('href', '#test');
   });
 });

--- a/src/components/common/HeaderCard/__test__/HeaderCard.test.to.ts
+++ b/src/components/common/HeaderCard/__test__/HeaderCard.test.to.ts
@@ -1,19 +1,10 @@
-import { renderWithProviders } from '@/lib/test/renderWithProviders';
-import { HeaderCard } from '..';
 import { BasePageClass } from '@/lib/test/BasePageClass.to';
 import { RenderResult } from '@testing-library/react';
 
-class HeaderCardPage extends BasePageClass {
+export class HeaderCardPage extends BasePageClass {
   number: HTMLElement;
   constructor(result: RenderResult) {
     super(result);
     this.number = result.getByText('01');
   }
 }
-
-describe('HeaderCard PO', () => {
-  it('exposes number element', () => {
-    const page = new HeaderCardPage(renderWithProviders(<HeaderCard number="01" label="Label" />));
-    expect(page.number).toBeInTheDocument();
-  });
-});

--- a/src/components/common/HeaderCard/__test__/HeaderCard.test.tsx
+++ b/src/components/common/HeaderCard/__test__/HeaderCard.test.tsx
@@ -1,11 +1,12 @@
 import { renderWithProviders } from '@/lib/test/renderWithProviders';
 import { HeaderCard } from '..';
 import { screen } from '@testing-library/react';
+import { HeaderCardPage } from './HeaderCard.test.to';
 
 describe('HeaderCard', () => {
   it('renders number and label', () => {
-    renderWithProviders(<HeaderCard number="01" label="Label" />);
-    expect(screen.getByText('01')).toBeInTheDocument();
+    const page = new HeaderCardPage(renderWithProviders(<HeaderCard number="01" label="Label" />));
+    expect(page.number).toBeInTheDocument();
     expect(screen.getByText('Label')).toBeInTheDocument();
   });
 });

--- a/src/components/common/JsonLdSchema/__test__/JsonLdSchema.test.to.ts
+++ b/src/components/common/JsonLdSchema/__test__/JsonLdSchema.test.to.ts
@@ -1,19 +1,10 @@
-import { renderWithProviders } from '@/lib/test/renderWithProviders';
-import JsonLdSchema from '..';
 import { BasePageClass } from '@/lib/test/BasePageClass.to';
 import { RenderResult } from '@testing-library/react';
 
-class JsonLdSchemaPage extends BasePageClass {
+export class JsonLdSchemaPage extends BasePageClass {
   script: HTMLElement | null;
   constructor(result: RenderResult) {
     super(result);
     this.script = document.getElementById('yoelvys-schema');
   }
 }
-
-describe('JsonLdSchema PO', () => {
-  it('exposes script element', () => {
-    const page = new JsonLdSchemaPage(renderWithProviders(<JsonLdSchema schemaData={{ name: 'Test' }} />));
-    expect(page.script).toBeInTheDocument();
-  });
-});

--- a/src/components/common/JsonLdSchema/__test__/JsonLdSchema.test.tsx
+++ b/src/components/common/JsonLdSchema/__test__/JsonLdSchema.test.tsx
@@ -1,11 +1,11 @@
 import { renderWithProviders } from '@/lib/test/renderWithProviders';
 import JsonLdSchema from '..';
+import { JsonLdSchemaPage } from './JsonLdSchema.test.to';
 
 describe('JsonLdSchema', () => {
   it('renders script tag', () => {
     const schema = { name: 'Test' };
-    renderWithProviders(<JsonLdSchema schemaData={schema} />);
-    const script = document.getElementById('yoelvys-schema');
-    expect(script).toBeInTheDocument();
+    const page = new JsonLdSchemaPage(renderWithProviders(<JsonLdSchema schemaData={schema} />));
+    expect(page.script).toBeInTheDocument();
   });
 });

--- a/src/components/common/LanguageSwitcher/__test__/LanguageSwitcher.test.to.ts
+++ b/src/components/common/LanguageSwitcher/__test__/LanguageSwitcher.test.to.ts
@@ -1,10 +1,8 @@
-import { renderWithProviders } from '@/lib/test/renderWithProviders';
-import { LanguageSwitcher } from '..';
 import { BasePageClass } from '@/lib/test/BasePageClass.to';
 import { RenderResult } from '@testing-library/react';
 import { ButtonTO } from '@/lib/test/Button.to';
 
-class LanguageSwitcherPage extends BasePageClass {
+export class LanguageSwitcherPage extends BasePageClass {
   en: ButtonTO;
   es: ButtonTO;
   constructor(result: RenderResult) {
@@ -13,11 +11,3 @@ class LanguageSwitcherPage extends BasePageClass {
     this.es = new ButtonTO(result, 'Switch to Spanish');
   }
 }
-
-describe('LanguageSwitcher PO', () => {
-  it('exposes language buttons', () => {
-    const page = new LanguageSwitcherPage(renderWithProviders(<LanguageSwitcher />));
-    expect(page.en.element).toBeInTheDocument();
-    expect(page.es.element).toBeInTheDocument();
-  });
-});

--- a/src/components/common/LanguageSwitcher/__test__/LanguageSwitcher.test.tsx
+++ b/src/components/common/LanguageSwitcher/__test__/LanguageSwitcher.test.tsx
@@ -1,11 +1,12 @@
 import { renderWithProviders } from '@/lib/test/renderWithProviders';
 import { LanguageSwitcher } from '..';
 import { screen } from '@testing-library/react';
+import { LanguageSwitcherPage } from './LanguageSwitcher.test.to';
 
 describe('LanguageSwitcher', () => {
   it('renders buttons for languages', () => {
-    renderWithProviders(<LanguageSwitcher />);
-    expect(screen.getByRole('button', { name: /english/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /spanish/i })).toBeInTheDocument();
+    const page = new LanguageSwitcherPage(renderWithProviders(<LanguageSwitcher />));
+    expect(page.en.element).toBeInTheDocument();
+    expect(page.es.element).toBeInTheDocument();
   });
 });

--- a/src/components/common/Modal/__test__/Modal.test.to.ts
+++ b/src/components/common/Modal/__test__/Modal.test.to.ts
@@ -1,19 +1,10 @@
-import { renderWithProviders } from '@/lib/test/renderWithProviders';
-import { Modal } from '..';
 import { BasePageClass } from '@/lib/test/BasePageClass.to';
 import { RenderResult } from '@testing-library/react';
 
-class ModalPage extends BasePageClass {
+export class ModalPage extends BasePageClass {
   title: HTMLElement;
   constructor(result: RenderResult) {
     super(result);
     this.title = result.getByText('T');
   }
 }
-
-describe('Modal PO', () => {
-  it('exposes title element when open', () => {
-    const page = new ModalPage(renderWithProviders(<Modal isOpen title="T">C</Modal>));
-    expect(page.title).toBeInTheDocument();
-  });
-});

--- a/src/components/common/Modal/__test__/Modal.test.tsx
+++ b/src/components/common/Modal/__test__/Modal.test.tsx
@@ -1,11 +1,12 @@
 import { renderWithProviders } from '@/lib/test/renderWithProviders';
 import { Modal } from '..';
 import { screen } from '@testing-library/react';
+import { ModalPage } from './Modal.test.to';
 
 describe('Modal', () => {
   it('renders when open', () => {
-    renderWithProviders(<Modal isOpen title="T">Content</Modal>);
-    expect(screen.getByText('T')).toBeInTheDocument();
+    const page = new ModalPage(renderWithProviders(<Modal isOpen title="T">Content</Modal>));
+    expect(page.title).toBeInTheDocument();
   });
 
   it('does not render when closed', () => {

--- a/src/components/common/Navigator/__test__/Navigator.test.to.ts
+++ b/src/components/common/Navigator/__test__/Navigator.test.to.ts
@@ -1,19 +1,10 @@
-import { renderWithProviders } from '@/lib/test/renderWithProviders';
-import { Navigator } from '..';
 import { BasePageClass } from '@/lib/test/BasePageClass.to';
 import { RenderResult } from '@testing-library/react';
 
-class NavigatorPage extends BasePageClass {
+export class NavigatorPage extends BasePageClass {
   nav: HTMLElement;
   constructor(result: RenderResult) {
     super(result);
     this.nav = result.getByRole('navigation');
   }
 }
-
-describe('Navigator PO', () => {
-  it('exposes navigation element', () => {
-    const page = new NavigatorPage(renderWithProviders(<Navigator />));
-    expect(page.nav).toBeInTheDocument();
-  });
-});

--- a/src/components/common/Navigator/__test__/Navigator.test.tsx
+++ b/src/components/common/Navigator/__test__/Navigator.test.tsx
@@ -1,10 +1,36 @@
 import { renderWithProviders } from '@/lib/test/renderWithProviders';
 import { Navigator } from '..';
-import { screen } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/react';
+import { NavigatorPage } from './Navigator.test.to';
+import { useRouter, usePathname } from 'next/navigation';
+jest.mock('@/hook/useViewports', () => ({ useViewports: jest.fn() }));
+import { useViewports } from '@/hook/useViewports';
+import gsap from 'gsap';
 
 describe('Navigator', () => {
   it('renders navigation container', () => {
-    renderWithProviders(<Navigator />);
-    expect(screen.getByRole('navigation')).toBeInTheDocument();
+    (useViewports as jest.Mock).mockReturnValue({ breakpoint: 'desktop' });
+    const page = new NavigatorPage(renderWithProviders(<Navigator />));
+    expect(page.nav).toBeInTheDocument();
+  });
+
+  it('toggles menu open on button click', () => {
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+    (usePathname as jest.Mock).mockReturnValue('/');
+    (useViewports as jest.Mock).mockReturnValue({ breakpoint: 'mobile' });
+    const page = new NavigatorPage(renderWithProviders(<Navigator />));
+    const button = page.container.querySelector('.button') as HTMLElement;
+    fireEvent.click(button);
+    expect(page.container.querySelector('.open')).toBeInTheDocument();
+  });
+
+  it('scrolls when link clicked on home page', () => {
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+    (usePathname as jest.Mock).mockReturnValue('/');
+    (useViewports as jest.Mock).mockReturnValue({ breakpoint: 'desktop' });
+    const page = new NavigatorPage(renderWithProviders(<Navigator />));
+    const firstLink = page.container.querySelector('li') as HTMLElement;
+    fireEvent.click(firstLink);
+    expect(gsap.to).toHaveBeenCalled();
   });
 });

--- a/src/components/common/ProjectImages/__test__/ProjectImages.test.to.ts
+++ b/src/components/common/ProjectImages/__test__/ProjectImages.test.to.ts
@@ -1,19 +1,10 @@
-import { renderWithProviders } from '@/lib/test/renderWithProviders';
-import { ProjectImages } from '..';
 import { BasePageClass } from '@/lib/test/BasePageClass.to';
 import { RenderResult } from '@testing-library/react';
 
-class ProjectImagesPage extends BasePageClass {
+export class ProjectImagesPage extends BasePageClass {
   images: HTMLElement[];
   constructor(result: RenderResult) {
     super(result);
     this.images = result.getAllByRole('img');
   }
 }
-
-describe('ProjectImages PO', () => {
-  it('exposes images list', () => {
-    const page = new ProjectImagesPage(renderWithProviders(<ProjectImages images={["a.png"]} />));
-    expect(page.images.length).toBe(1);
-  });
-});

--- a/src/components/common/ProjectImages/__test__/ProjectImages.test.tsx
+++ b/src/components/common/ProjectImages/__test__/ProjectImages.test.tsx
@@ -1,10 +1,21 @@
 import { renderWithProviders } from '@/lib/test/renderWithProviders';
 import { ProjectImages } from '..';
 import { screen } from '@testing-library/react';
+import { ProjectImagesPage } from './ProjectImages.test.to';
 
 describe('ProjectImages', () => {
   it('renders all images', () => {
-    renderWithProviders(<ProjectImages images={["a.png", "b.png"]} />);
-    expect(screen.getAllByRole('img')).toHaveLength(2);
+    const page = new ProjectImagesPage(
+      renderWithProviders(<ProjectImages images={["a.png", "b.png"]} />),
+    );
+    expect(page.images.length).toBe(2);
+  });
+
+  it('renders navigation buttons', () => {
+    renderWithProviders(<ProjectImages images={["a.png"]} />);
+    expect(screen.getByRole('button', { name: 'previous image' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'next image' })).toBeInTheDocument();
+    screen.getByRole('button', { name: 'next image' }).click();
+    screen.getByRole('button', { name: 'previous image' }).click();
   });
 });

--- a/src/components/common/ProjectItem/__test__/ProjectItem.test.to.ts
+++ b/src/components/common/ProjectItem/__test__/ProjectItem.test.to.ts
@@ -1,21 +1,10 @@
-import { renderWithProviders } from '@/lib/test/renderWithProviders';
-import { ProjectItem } from '..';
 import { BasePageClass } from '@/lib/test/BasePageClass.to';
 import { RenderResult } from '@testing-library/react';
 
-class ProjectItemPage extends BasePageClass {
+export class ProjectItemPage extends BasePageClass {
   title: HTMLElement;
   constructor(result: RenderResult) {
     super(result);
     this.title = result.getByText('Proj');
   }
 }
-
-describe('ProjectItem PO', () => {
-  it('exposes title element', () => {
-    const page = new ProjectItemPage(renderWithProviders(
-      <ProjectItem id="1" title="Proj" description={['desc']} technologies={[]} imagesUrl={[]} align="left" />
-    ));
-    expect(page.title).toBeInTheDocument();
-  });
-});

--- a/src/components/common/ProjectItem/__test__/ProjectItem.test.tsx
+++ b/src/components/common/ProjectItem/__test__/ProjectItem.test.tsx
@@ -1,13 +1,16 @@
 import { renderWithProviders } from '@/lib/test/renderWithProviders';
 import { ProjectItem } from '..';
 import { screen } from '@testing-library/react';
+import { ProjectItemPage } from './ProjectItem.test.to';
 
 describe('ProjectItem', () => {
   it('renders title and description', () => {
-    renderWithProviders(
-      <ProjectItem id="1" title="Proj" description={['desc']} technologies={[]} imagesUrl={[]} align="left" />
+    const page = new ProjectItemPage(
+      renderWithProviders(
+        <ProjectItem id="1" title="Proj" description={['desc']} technologies={[]} imagesUrl={[]} align="left" />,
+      ),
     );
-    expect(screen.getByText('Proj')).toBeInTheDocument();
+    expect(page.title).toBeInTheDocument();
     expect(screen.getByText('desc')).toBeInTheDocument();
   });
 });

--- a/src/components/common/ProjectsCard/__test__/ProjectsCard.test.to.ts
+++ b/src/components/common/ProjectsCard/__test__/ProjectsCard.test.to.ts
@@ -1,20 +1,11 @@
-import { renderWithProviders } from '@/lib/test/renderWithProviders';
-import { ProjectsCard } from '..';
 import { BasePageClass } from '@/lib/test/BasePageClass.to';
 import { ButtonTO } from '@/lib/test/Button.to';
 import { RenderResult } from '@testing-library/react';
 
-class ProjectsCardPage extends BasePageClass {
+export class ProjectsCardPage extends BasePageClass {
   btn: ButtonTO;
   constructor(result: RenderResult) {
     super(result);
     this.btn = new ButtonTO(result, 'circle button');
   }
 }
-
-describe('ProjectsCard PO', () => {
-  it('exposes circle button', () => {
-    const page = new ProjectsCardPage(renderWithProviders(<ProjectsCard number="01" title="t" content="c" />));
-    expect(page.btn.element).toBeInTheDocument();
-  });
-});

--- a/src/components/common/ProjectsCard/__test__/ProjectsCard.test.tsx
+++ b/src/components/common/ProjectsCard/__test__/ProjectsCard.test.tsx
@@ -1,11 +1,13 @@
 import { renderWithProviders } from '@/lib/test/renderWithProviders';
 import { ProjectsCard } from '..';
 import { screen } from '@testing-library/react';
+import { ProjectsCardPage } from './ProjectsCard.test.to';
 
 describe('ProjectsCard', () => {
   it('renders content', () => {
-    renderWithProviders(<ProjectsCard number="01" title="t" content="c" />);
+    const page = new ProjectsCardPage(renderWithProviders(<ProjectsCard number="01" title="t" content="c" />));
     expect(screen.getByText('t')).toBeInTheDocument();
     expect(screen.getByText('c')).toBeInTheDocument();
+    expect(page.btn.element).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- use page object classes exported from `*.test.to.ts`
- rewrite component tests to import page objects
- add interaction tests for better coverage
- ensure helper files contain no test descriptions

## Testing
- `yarn test --coverage`
- `yarn stryker` *(fails: Final mutation score 23.56 under breaking threshold 50)*

------
https://chatgpt.com/codex/tasks/task_e_687c5e065c888320832f4adfe9594a05