### PR TITLE
Fix ESLint warning in not-found page

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,7 +1,6 @@
 import { NextIntlClientProvider, useTranslations } from 'next-intl';
-import { routing } from '@/navigation';
+import { routing, Link } from '@/navigation';
 import { loadMessages } from '../i18n/request';
-import { Link } from '@/navigation';
 
 function NotFoundContent() {
   const t = useTranslations('common.notFound');


### PR DESCRIPTION
## Summary
- consolidate duplicate imports in `not-found.tsx`

## Testing
- `yarn run lint`
- `yarn run build`


------
https://chatgpt.com/codex/tasks/task_e_6886ab4b02f483209772b6a3394cc2d1