### PR TITLE
refactor: dynamically import Swiper

### DIFF
--- a/src/components/common/ProjectImages/index.tsx
+++ b/src/components/common/ProjectImages/index.tsx
@@ -2,12 +2,21 @@
 
 import { CustomImage } from '../CustomImage';
 import styles from './ProjectImages.module.scss';
-import { Swiper, SwiperSlide } from 'swiper/react';
-import { Navigation, Autoplay } from 'swiper/modules';
-import { useRef } from 'react';
+import dynamic from 'next/dynamic';
+import { useEffect, useRef, useState } from 'react';
 import ArrowIcon from '../Icons/ArrowIcon';
-import 'swiper/css';
-import 'swiper/css/navigation';
+import type { SwiperModule } from 'swiper/types';
+
+const Swiper = dynamic(() => import('swiper/react').then((mod) => mod.Swiper), {
+  ssr: false,
+});
+
+const SwiperSlide = dynamic(
+  () => import('swiper/react').then((mod) => mod.SwiperSlide),
+  {
+    ssr: false,
+  },
+);
 
 interface Props {
   images: string[];
@@ -16,10 +25,24 @@ interface Props {
 export const ProjectImages = ({ images }: Props) => {
   const prevRef = useRef<HTMLButtonElement>(null);
   const nextRef = useRef<HTMLButtonElement>(null);
+  const [modules, setModules] = useState<SwiperModule[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      await Promise.all([
+        import('swiper/css'),
+        import('swiper/css/navigation'),
+      ]);
+      const mod = await import('swiper/modules');
+      setModules([mod.Navigation, mod.Autoplay]);
+    };
+
+    load();
+  }, []);
 
   return (
     <Swiper
-      modules={[Navigation, Autoplay]}
+      modules={modules}
       slidesPerView={1}
       navigation={{
         prevEl: prevRef.current,

--- a/swiper-css.d.ts
+++ b/swiper-css.d.ts
@@ -1,0 +1,2 @@
+declare module 'swiper/css';
+declare module 'swiper/css/navigation';


### PR DESCRIPTION
## Summary
- dynamically import Swiper and SwiperSlide
- load Swiper modules and styles on the client

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688f90134ca48320aa4cadc2a12193bd