### PR TITLE
feat: add responsive styles

### DIFF
--- a/src/components/sections/home/About/About.module.scss
+++ b/src/components/sections/home/About/About.module.scss
@@ -1,13 +1,20 @@
 @use '@/styles/variables/colors' as cl;
+@use '@/styles/variables/typography' as ty;
 @use '@/styles/mixins/mixins' as mx;
+@use '@/styles/mixins/functions' as fn;
 
 .about {
   display: flex;
-  height: 100vh;
-  align-items: flex-end;
-  justify-content: center;
-  margin-bottom: 50vh;
-  color: rgb(211, 211, 211);
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  color: rgba(cl.$color__white, 0.83);
+  margin-bottom: fn.rem(80px);
+
+  @include mx.respond-to('tablet') {
+    height: 100vh;
+    margin-bottom: 50vh;
+  }
 }
 
 .content {
@@ -17,10 +24,20 @@
   justify-content: center;
 
   p {
-    font-size: 36px;
-    margin: 0px;
-    margin-right: 22px;
+    font-family: ty.$font__main;
+    font-size: fn.rem(24px);
+    margin: 0;
+    margin-right: fn.rem(12px);
     font-weight: 400;
+
+    @include mx.respond-to('tablet') {
+      font-size: fn.rem(32px);
+      margin-right: fn.rem(18px);
+    }
+    @include mx.respond-to('desktop') {
+      font-size: fn.rem(36px);
+      margin-right: fn.rem(22px);
+    }
   }
   span {
     opacity: 0.2;

--- a/src/components/sections/home/Experience/Experience.module.scss
+++ b/src/components/sections/home/Experience/Experience.module.scss
@@ -1,55 +1,57 @@
 @use '@/styles/variables/colors' as cl;
 @use '@/styles/mixins/mixins' as mx;
 @use '@/styles/variables/typography' as ty;
+@use '@/styles/mixins/functions' as fn;
 
 .section {
-  color: rgba(255, 255, 255, 0.85);
-  padding: clamp(48px, 8vw, 96px) 0;
+  color: rgba(cl.$color__white, 0.85);
+  padding: clamp(fn.rem(48px), 8vw, fn.rem(96px)) 0;
   height: 100%;
   max-height: 100%;
 }
 
 .container {
-  width: min(1180px, 92vw);
+  width: min(fn.rem(1180px), 92vw);
   margin-inline: auto;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 100px;
+  gap: fn.rem(100px);
 }
 
 .title {
   text-align: center;
   font-family: ty.$font__secondary;
-  font-size: 32px;
+  font-size: fn.rem(32px);
   font-weight: 400;
-  color: #ffffff;
+  color: cl.$color__white;
 
   @include mx.respond-to('tablet') {
-    font-size: 54px;
+    font-size: fn.rem(54px);
   }
   @include mx.respond-to('desktop') {
-    font-size: 64px;
+    font-size: fn.rem(64px);
   }
 
   span {
-    color: #86a7ff;
+    color: cl.$color__accent;
   }
 }
 
+
 .timeline {
   position: relative;
-  padding-left: clamp(72px, 9vw, 120px);
+  padding-left: clamp(fn.rem(72px), 9vw, fn.rem(120px));
 
   &::before {
     content: '';
     position: absolute;
-    left: clamp(32px, 5vw, 52px);
-    top: 12px;
+    left: clamp(fn.rem(32px), 5vw, fn.rem(52px));
+    top: fn.rem(12px);
     bottom: 0;
-    width: 2px;
-    background: linear-gradient(180deg, #6f85ff, rgba(111, 133, 255, 0.25));
+    width: fn.rem(2px);
+    background: linear-gradient(180deg, cl.$color__cornflower-blue, rgba(111, 133, 255, 0.25));
     opacity: 0.9;
   }
 }
@@ -57,21 +59,25 @@
 .item {
   position: relative;
   display: grid;
-  grid-template-columns: clamp(180px, 24vw, 280px) 1fr;
-  gap: clamp(24px, 5vw, 64px);
-  padding-bottom: clamp(56px, 10vw, 140px);
+  grid-template-columns: 1fr;
+  gap: clamp(fn.rem(24px), 5vw, fn.rem(64px));
+  padding-bottom: clamp(fn.rem(56px), 10vw, fn.rem(140px));
+
+  @include mx.respond-to('tablet') {
+    grid-template-columns: clamp(fn.rem(180px), 24vw, fn.rem(280px)) 1fr;
+  }
 }
 
 .marker {
   position: absolute;
-  left: calc(clamp(32px, 5vw, 52px) - 7px);
-  top: 8px;
-  width: 14px;
-  height: 14px;
+  left: calc(clamp(fn.rem(32px), 5vw, fn.rem(52px)) - fn.rem(7px));
+  top: fn.rem(8px);
+  width: fn.rem(14px);
+  height: fn.rem(14px);
   border-radius: 50%;
-  background: #88a0ff;
-  box-shadow: 0 0 0 4px rgba(120, 161, 255, 0.18);
-  border: 3px solid #2b2f55;
+  background: cl.$color__accent-light;
+  box-shadow: 0 0 0 fn.rem(4px) rgba(cl.$color__accent-light, 0.18);
+  border: fn.rem(3px) solid cl.$color__dark-indigo;
 }
 
 .left {
@@ -80,50 +86,44 @@
 
 .period {
   font-family: ty.$font__secondary;
-  font-size: 32px;
+  font-size: fn.rem(32px);
   text-transform: uppercase;
-  letter-spacing: -0.32px;
-  color: #d8dcff;
-  margin: 0 0 6px;
-  color: #ffffff;
+  letter-spacing: fn.rem(-0.32px);
+  color: cl.$color__periwinkle;
+  margin: 0 0 fn.rem(6px);
+  color: cl.$color__white;
 }
 
 .company {
   margin: 0;
-  color: #ffffff;
-  font-size: 32px;
+  color: cl.$color__white;
+  font-size: fn.rem(32px);
   font-weight: 500;
 }
 
 .right {
-  max-width: 720px;
+  max-width: fn.rem(720px);
 }
 
 .paragraph {
-  margin: 0 0 16px;
-  color: #ffffff;
-  font-size: 20px;
-  line-height: 28px;
+  margin: 0 0 fn.rem(16px);
+  color: cl.$color__white;
+  font-size: fn.rem(20px);
+  line-height: fn.rem(28px);
 }
 
 .gallery {
-  margin-top: clamp(12px, 2vw, 20px);
+  margin-top: clamp(fn.rem(12px), 2vw, fn.rem(20px));
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: clamp(12px, 2vw, 20px);
+  gap: clamp(fn.rem(12px), 2vw, fn.rem(20px));
 }
 
 .thumb img {
   display: block;
   width: 100%;
   height: auto;
-  border-radius: 24px;
-  outline: 1px solid rgba(255, 255, 255, 0.06);
-  background: #11131a;
-}
-
-@media (max-width: 820px) {
-  .item {
-    grid-template-columns: 1fr;
-  }
+  border-radius: fn.rem(24px);
+  outline: fn.rem(1px) solid rgba(cl.$color__white, 0.06);
+  background: cl.$color__dark-charcoal;
 }

--- a/src/components/sections/home/Header/Header.module.scss
+++ b/src/components/sections/home/Header/Header.module.scss
@@ -1,11 +1,12 @@
 @use '@/styles/variables/colors' as cl;
 @use '@/styles/variables/typography' as ty;
 @use '@/styles/mixins/mixins' as mx;
+@use '@/styles/mixins/functions' as fn;
 
 .header {
   position: relative;
   isolation: isolate;
-  padding: 0 16px;
+  padding: 0 fn.rem(16px);
   display: grid;
   place-items: center;
   min-height: 100svh;
@@ -19,48 +20,63 @@
 .content {
   text-align: center;
   margin-inline: auto;
-  max-width: 920px;
+  max-width: fn.rem(920px);
 
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 32px;
+  gap: fn.rem(32px);
 }
 
 .title {
   font-family: ty.$font__secondary;
   text-transform: uppercase;
-  font-size: 96px;
+  font-size: fn.rem(48px);
   line-height: normal;
   font-weight: 800;
-  color: #fff;
+  color: cl.$color__white;
+
+  @include mx.respond-to('tablet') {
+    font-size: fn.rem(72px);
+  }
+  @include mx.respond-to('desktop') {
+    font-size: fn.rem(96px);
+  }
 
   span {
-    color: #86a7ff;
+    color: cl.$color__accent;
   }
 }
 
 .description {
-  margin-top: 1.25rem;
-  color: rgba(255, 255, 255, 0.88);
-  font-size: 20px;
+  margin-top: fn.rem(12px);
+  color: rgba(cl.$color__white, 0.88);
+  font-size: fn.rem(20px);
   line-height: 140%;
-  max-width: 520px;
+  max-width: fn.rem(520px);
   letter-spacing: 0.02em;
+
+  @include mx.respond-to('tablet') {
+    margin-top: fn.rem(20px);
+  }
 }
 
 .buttons {
-  margin-top: 2rem;
+  margin-top: fn.rem(24px);
   display: flex;
   gap: 1rem;
   justify-content: center;
   flex-wrap: wrap;
+
+  @include mx.respond-to('tablet') {
+    margin-top: fn.rem(32px);
+  }
 }
 
 .button {
   /* Asegura foco visible si el botón no lo define internamente */
   &:focus-visible {
-    outline: 2px solid #86a7ff;
+    outline: fn.rem(2px) solid cl.$color__accent;
     outline-offset: 2px;
   }
 }
@@ -115,12 +131,4 @@
   top: 60%;
 }
 
-/* Responsivo fino */
-@media (max-width: 640px) {
-  .description {
-    margin-top: 0.75rem;
-  }
-  .buttons {
-    margin-top: 1.5rem;
-  }
-}
+/* Responsivo fino handled above with mixins */

--- a/src/components/sections/home/Projects/Projects.module.scss
+++ b/src/components/sections/home/Projects/Projects.module.scss
@@ -1,40 +1,41 @@
 @use '@/styles/variables/colors' as cl;
 @use '@/styles/variables/typography' as ty;
 @use '@/styles/mixins/mixins' as mx;
+@use '@/styles/mixins/functions' as fn;
 
 .projects {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 40px;
+  gap: fn.rem(32px);
   max-width: 100%;
   height: auto;
   max-height: 100%;
-  padding: 100px 0 100px;
+  padding: fn.rems(80px 0 80px);
 
   @include mx.respond-to('tablet') {
-    padding: 140px 0 100px;
-    gap: 50px;
+    padding: fn.rems(140px 0 100px);
+    gap: fn.rem(50px);
   }
   @include mx.respond-to('desktop') {
-    gap: 60px;
+    gap: fn.rem(60px);
   }
 
   h2 {
     font-family: ty.$font__secondary;
-    font-size: 32px;
+    font-size: fn.rem(32px);
     font-weight: 400;
-    color: #ffffff;
+    color: cl.$color__white;
 
     @include mx.respond-to('tablet') {
-      font-size: 54px;
+      font-size: fn.rem(54px);
     }
     @include mx.respond-to('desktop') {
-      font-size: 64px;
+      font-size: fn.rem(64px);
     }
 
     span {
-      color: #86a7ff;
+      color: cl.$color__accent;
     }
   }
 

--- a/src/components/sections/home/Skills/Skills.module.scss
+++ b/src/components/sections/home/Skills/Skills.module.scss
@@ -1,44 +1,52 @@
 @use '@/styles/variables/colors' as cl;
 @use '@/styles/mixins/mixins' as mx;
 @use '@/styles/variables/typography' as ty;
+@use '@/styles/mixins/functions' as fn;
 
 .section {
-  color: rgba(255, 255, 255, 0.88);
-  padding-block: clamp(64px, 12vw, 160px);
+  color: rgba(cl.$color__white, 0.88);
+  padding-block: clamp(fn.rem(64px), 12vw, fn.rem(160px));
 }
 
 .container {
-  width: min(980px, 92vw);
+  width: min(fn.rem(980px), 92vw);
   margin-inline: auto;
   text-align: center;
 
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 32px;
+  gap: fn.rem(32px);
 }
 
 .title {
   font-family: ty.$font__secondary;
-  font-size: 32px;
+  font-size: fn.rem(32px);
   font-weight: 400;
-  color: #ffffff;
+  color: cl.$color__white;
 
   @include mx.respond-to('tablet') {
-    font-size: 54px;
+    font-size: fn.rem(54px);
   }
   @include mx.respond-to('desktop') {
-    font-size: 64px;
+    font-size: fn.rem(64px);
   }
 
   span {
-    color: #86a7ff;
+    color: cl.$color__accent;
   }
 }
 
 .subtitle {
   margin: 0 auto;
-  max-width: 970px;
-  font-size: 36px;
-  color: #ffffff;
+  max-width: fn.rem(970px);
+  font-size: fn.rem(24px);
+  color: cl.$color__white;
+
+  @include mx.respond-to('tablet') {
+    font-size: fn.rem(30px);
+  }
+  @include mx.respond-to('desktop') {
+    font-size: fn.rem(36px);
+  }
 }

--- a/src/styles/variables/_colors.scss
+++ b/src/styles/variables/_colors.scss
@@ -7,6 +7,14 @@ $color__pink-purple: #7779e7;
 $color__violet-blue: #9bcffc;
 $color__sky-blue: #9bcffc;
 
+// Additional palette
+$color__accent: #86a7ff;
+$color__accent-light: #88a0ff;
+$color__cornflower-blue: #6f85ff;
+$color__periwinkle: #d8dcff;
+$color__dark-indigo: #2b2f55;
+$color__dark-charcoal: #11131a;
+
 $color__linear-gradient: linear-gradient(
   to right,
   $color__pink-purple 0%,


### PR DESCRIPTION
## Summary
- add accent color variables
- convert home sections to rem units and responsive mixins

## Testing
- `yarn lint | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689f8b47d6c48320b972303b06058f91